### PR TITLE
WP-006: Fixing PostgreSQL image version

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgis/postgis:14-3.3
+        image: postgres:14.9
         env:
           POSTGRES_USER: ${{ secrets.POSTGRES_USERNAME }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   database:
     container_name: database
-    image: postgis/postgis:14-3.3
+    image: postgres:14.9
     restart: always
     ports:
       - 5432:5432


### PR DESCRIPTION
## 👨🏽‍💻 Description

This changes contain a quick fix to fix the version of the image for the PostgreSQL container. The reason is because the previous one was `postgis/postgis:14-3.3` which is specific for `x86_64`, the new one is `1postgis/postgis:14-3.3` which also support `arm64`.

## ✅ Testing

I successfully built and ran the compose swarm within an `arm64` machine and also in an `x86_64` machine. Also, verified the pipeline continue passing.

## 🖼️ Evidence

Following is the screenshot of the build on `arm64`:

![image](https://github.com/zatarain/white-pages/assets/539783/5860c97e-735c-4b37-b4af-4fd648cc7100)

And in `x86_64`:

![image](https://github.com/zatarain/white-pages/assets/539783/b743cc4c-7fc0-4cea-b7f8-7921a9ffab07)
