### PR TITLE
WP-XXX: Removing version from docker compose manifest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   consumermanager:
     container_name: api-service


### PR DESCRIPTION
## 👨🏽‍💻 Description

Removing version from docker compose manifest as it's obsolete.

## ✅ Testing

How did you test your changes?

* [x] ♻️ Verify all unit test still passing
